### PR TITLE
Schedule the brightness update task for Sponge...

### DIFF
--- a/src/main/java/pcl/openlights/tileentity/OpenLightTE.java
+++ b/src/main/java/pcl/openlights/tileentity/OpenLightTE.java
@@ -14,6 +14,7 @@ import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -100,9 +101,16 @@ public class OpenLightTE extends TileEntity implements SimpleComponent, ILightPr
 			throw new Exception( "Valid brightness range is 0 to 15" );
 		
 		brightness = buf;
-		
-		IBlockState state = world.getBlockState( pos );
-		world.setBlockState( pos, state.withProperty( LightBlock.BRIGHTNESS, brightness ) );
+
+		( ( WorldServer ) world ).addScheduledTask( new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				IBlockState state = world.getBlockState( pos );
+				world.setBlockState( pos, state.withProperty( LightBlock.BRIGHTNESS, brightness ) );
+			}
+		});
 		
 		getUpdateTag();
 		world.notifyBlockUpdate( pos, world.getBlockState( pos ), world.getBlockState( pos ), 2 );


### PR DESCRIPTION
Upon continuing our build, we realized the "Illegal Async Block Change" issue had seemingly regressed when calling component.openlight.setBrightness(value)...  Further investigation revealed that this issue only occurred when Sponge was installed on the server.

Basically, Sponge overrides `net.minecraft.world.World.setBlockState( BlockPos, IBlockState )` with its own implementation which prevents this method from being called unless we are exclusively calling this method within the server thread itself.  The obvious solution to this is to schedule this task to run within the server thread.

Sponge's override can be seen here: https://github.com/SpongePowered/SpongeCommon/blob/c747699ce4d6429410cf947cee6c7d2a18e84eaf/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java#L751

@gabizou briefly mentions what is going on in this related issue: https://github.com/SpongePowered/SpongeForge/issues/2558
> [...] innate nature of what Sponge is doing to make most all of tracking and events work [...]
(so Sponge is overloading this for event and state tracking and such)

As I was searching for a solution, I noticed several major mods have also encountered this or a related error directly involving `org.spongepowered.common.event.tracking.PhaseTracker` and `net.minecraft.world.World.setBlockState( BlockPos, IBlockState )`.  Among them: EnderIO, Chisel, Blood Magic and Serene Seasons, just to name a few.