### PR TITLE
Fix a fatal client issue, a light level issue, & make use of ITickable in OpenLightTE for setting states.

### DIFF
--- a/src/main/java/pcl/openlights/ClientProxy.java
+++ b/src/main/java/pcl/openlights/ClientProxy.java
@@ -14,39 +14,41 @@ import pcl.openlights.blocks.LightBlock;
 import pcl.openlights.tileentity.OpenLightTE;
 import pcl.openlights.util.ConcurrentlyLoadedColoredLightsModException;
 
-public class ClientProxy extends CommonProxy {
+public class ClientProxy extends CommonProxy
+{
 	@Override
 	public void preInit()
 	{
 		// Be nice and error client if the erroneous condition of loading both Mirage and Albedo exists.
 		if( Loader.isModLoaded( "mirage" ) && Loader.isModLoaded( "albedo" ) )
-				throw new ConcurrentlyLoadedColoredLightsModException();
-	}
-	
-	@Override
-	public void registerColorHandler() {
-		Minecraft mc = Minecraft.getMinecraft();
-		mc.getBlockColors().registerBlockColorHandler(new BlockColorHandler(), ContentRegistry.openLightBlock);
+			throw new ConcurrentlyLoadedColoredLightsModException();
 	}
 
-	@SideOnly(Side.CLIENT)
-	private static class BlockColorHandler implements IBlockColor {
+	@Override
+	public void registerColorHandler()
+	{
+		Minecraft.getMinecraft().getBlockColors().registerBlockColorHandler( new BlockColorHandler(), ContentRegistry.openLightBlock );
+	}
+
+	@SideOnly( Side.CLIENT )
+	private static class BlockColorHandler implements IBlockColor
+	{
 		@Override
-		public int colorMultiplier(IBlockState state, IBlockAccess worldIn, BlockPos pos, int tintIndex) {
-			if (pos != null && state != null && state.getBlock() instanceof LightBlock) {
-				OpenLightTE te = (OpenLightTE) worldIn.getTileEntity(pos);
-				int color = Integer.parseInt(te.getColor(), 16);
-				return color;
-			}
-			else
-				return 0;
+		public int colorMultiplier( IBlockState state, IBlockAccess worldIn, BlockPos pos, int tintIndex )
+		{
+			int RetVal = 0;
+
+			if( ( pos != null ) && ( state != null ) && ( state.getBlock() instanceof LightBlock ) && ( worldIn.getTileEntity( pos ) instanceof OpenLightTE ) )
+				RetVal = ( ( OpenLightTE ) worldIn.getTileEntity( pos ) ).getColor();
+
+			return RetVal;
 		}
 	}
-	
-	@Override
-	public void registerModels() {
-		ModelLoader.setCustomModelResourceLocation(ContentRegistry.prismaticPaste,  0, new ModelResourceLocation(ContentRegistry.prismaticPaste.getRegistryName(), "inventory"));
-		ModelLoader.setCustomModelResourceLocation(ContentRegistry.openLightItem,  0, new ModelResourceLocation(ContentRegistry.openLightItem.getRegistryName(), "inventory"));
-	}
 
+	@Override
+	public void registerModels()
+	{
+		ModelLoader.setCustomModelResourceLocation( ContentRegistry.prismaticPaste, 0, new ModelResourceLocation( ContentRegistry.prismaticPaste.getRegistryName(), "inventory" ) );
+		ModelLoader.setCustomModelResourceLocation( ContentRegistry.openLightItem, 0, new ModelResourceLocation( ContentRegistry.openLightItem.getRegistryName(), "inventory" ) );
+	}
 }

--- a/src/main/java/pcl/openlights/CommonProxy.java
+++ b/src/main/java/pcl/openlights/CommonProxy.java
@@ -7,27 +7,26 @@ package pcl.openlights;
  * @author Caitlyn
  *
  */
-public class CommonProxy {
+public class CommonProxy
+{
 
 	public void preInit()
 	{
 		// TODO Auto-generated method stub
-		
-	}
-	
-	public void registerRenderers() {
-		// TODO Auto-generated method stub
-		
 	}
 
-	public void registerColorHandler() {
+	public void registerRenderers()
+	{
 		// TODO Auto-generated method stub
-		
 	}
 
-	public void registerModels() {
+	public void registerColorHandler()
+	{
 		// TODO Auto-generated method stub
-		
 	}
 
+	public void registerModels()
+	{
+		// TODO Auto-generated method stub
+	}
 }

--- a/src/main/java/pcl/openlights/ContentRegistry.java
+++ b/src/main/java/pcl/openlights/ContentRegistry.java
@@ -14,30 +14,31 @@ import pcl.openlights.items.PrismaticPaste;
 import pcl.openlights.tileentity.OpenLightTE;
 
 @Mod.EventBusSubscriber
-public class ContentRegistry {
+public class ContentRegistry
+{
 	public static Block openLightBlock;
-	public static Item  prismaticPaste;
-    public static Item  openLightItem;
-    
+	public static Item prismaticPaste;
+	public static Item openLightItem;
+
 	@SubscribeEvent
-	public static void registerItems(RegistryEvent.Register<Item> event) {
+	public static void registerItems( RegistryEvent.Register< Item > event )
+	{
 		prismaticPaste = new PrismaticPaste();
-		openLightItem = new ItemBlock(openLightBlock).setRegistryName(openLightBlock.getRegistryName().toString());
-		event.getRegistry().registerAll(
-				prismaticPaste,
-				openLightItem
-				);
+		openLightItem = new ItemBlock( openLightBlock ).setRegistryName( openLightBlock.getRegistryName().toString() );
+		event.getRegistry().registerAll( prismaticPaste, openLightItem );
 	}
 
 	@SubscribeEvent
-	public static void registerBlocks(RegistryEvent.Register<Block> event) {
+	public static void registerBlocks( RegistryEvent.Register< Block > event )
+	{
 		openLightBlock = new LightBlock();
-		event.getRegistry().registerAll(openLightBlock);
-		registerTileEntity(OpenLightTE.class, "OpenLightTE");
+		event.getRegistry().registerAll( openLightBlock );
+		registerTileEntity( OpenLightTE.class, "OpenLightTE" );
 	}
 
-	private static void registerTileEntity(Class<? extends TileEntity> tileEntityClass, String key) {
+	private static void registerTileEntity( Class< ? extends TileEntity > tileEntityClass, String key )
+	{
 		// For better readability
-		GameRegistry.registerTileEntity(tileEntityClass, new ResourceLocation(OpenLights.MODID, key));
+		GameRegistry.registerTileEntity( tileEntityClass, new ResourceLocation( OpenLights.MODID, key ) );
 	}
 }

--- a/src/main/java/pcl/openlights/OpenLights.java
+++ b/src/main/java/pcl/openlights/OpenLights.java
@@ -17,41 +17,43 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
  */
 
 @Mod(
-		modid=OpenLights.MODID, name="OpenLights",
-		version=BuildInfo.versionNumber + "." + BuildInfo.buildNumber,
-		dependencies = "after:opencomputers;after:albedo@[0.1,);after:mirage@[2.0,)")
-
-public class OpenLights {
+		modid = OpenLights.MODID,
+		name = "OpenLights",
+		version = BuildInfo.versionNumber + "." + BuildInfo.buildNumber,
+		dependencies = "after:opencomputers;after:albedo@[0.1,);after:mirage@[2.0,)"
+)
+public class OpenLights
+{
 	public static final String MODID = "openlights";
 
-	@Instance(value = MODID)
+	@Instance( value = MODID )
 	public static OpenLights instance;
 
-	@SidedProxy(clientSide="pcl.openlights.ClientProxy", serverSide="pcl.openlights.CommonProxy")
+	@SidedProxy( clientSide = "pcl.openlights.ClientProxy", serverSide = "pcl.openlights.CommonProxy" )
 	public static CommonProxy proxy;
 	public static Config cfg = null;
 
 	private static boolean debug = true;
-    
+
 	@EventHandler
-	public void preInit(FMLPreInitializationEvent event)
+	public void preInit( FMLPreInitializationEvent event )
 	{
 		proxy.preInit();
-		MinecraftForge.EVENT_BUS.register(ContentRegistry.class);
-		MinecraftForge.EVENT_BUS.register(OpenLights.class);
-		cfg = new Config(new Configuration(event.getSuggestedConfigurationFile()));
+		MinecraftForge.EVENT_BUS.register( ContentRegistry.class );
+		MinecraftForge.EVENT_BUS.register( OpenLights.class );
+		cfg = new Config( new Configuration( event.getSuggestedConfigurationFile() ) );
 		proxy.registerRenderers();
 	}
-	
+
 	@EventHandler
-	public void load(FMLInitializationEvent event)
+	public void load( FMLInitializationEvent event )
 	{
 		proxy.registerColorHandler();
 	}
-	
-    @SubscribeEvent
-    public static void onRegisterModels(ModelRegistryEvent event) {
-        proxy.registerModels();
-    }
 
+	@SubscribeEvent
+	public static void onRegisterModels( ModelRegistryEvent event )
+	{
+		proxy.registerModels();
+	}
 }

--- a/src/main/java/pcl/openlights/blocks/LightBlock.java
+++ b/src/main/java/pcl/openlights/blocks/LightBlock.java
@@ -55,7 +55,12 @@ public class LightBlock extends Block implements ITileEntityProvider
 	@Override
 	public IBlockState getExtendedState( IBlockState state, IBlockAccess world, BlockPos pos )
 	{
-		return state.withProperty( BRIGHTNESS, state.getValue( BRIGHTNESS ) );
+		if( world.getTileEntity( pos ) instanceof OpenLightTE )
+		{
+			return state.withProperty( BRIGHTNESS, state.getValue( BRIGHTNESS ) );
+		}
+
+		return state;
 	}
 
 	@Override

--- a/src/main/java/pcl/openlights/blocks/LightBlock.java
+++ b/src/main/java/pcl/openlights/blocks/LightBlock.java
@@ -17,58 +17,64 @@ import net.minecraft.world.World;
 /**
  * @author Caitlyn
  */
-public class LightBlock extends Block implements ITileEntityProvider {
+public class LightBlock extends Block implements ITileEntityProvider
+{
 	public static final String NAME = "openlight";
-	public LightBlock() {
-		super(Material.GLASS);
-		setRegistryName(NAME);
-		setUnlocalizedName(NAME);
-		this.setHardness(.5F);
-		this.setLightLevel(1);
-		setCreativeTab(li.cil.oc.api.CreativeTab.instance);
+
+	public LightBlock()
+	{
+		super( Material.GLASS );
+		setRegistryName( NAME );
+		setUnlocalizedName( NAME );
+		setHardness( .5F );
+		setLightLevel( 1.0F );
+		setCreativeTab( li.cil.oc.api.CreativeTab.instance );
 	}
 
-	public static final PropertyInteger BRIGHTNESS = PropertyInteger.create("brightness", 0, 15);
+	public static final PropertyInteger BRIGHTNESS = PropertyInteger.create( "brightness", 0, 15 );
 
 	@Override
 	protected BlockStateContainer createBlockState()
 	{
-		return new BlockStateContainer(this, new IProperty[] {BRIGHTNESS});
+		return new BlockStateContainer( this, new IProperty[]{ BRIGHTNESS } );
 	}
 
 	@Override
 	@Deprecated
-	public IBlockState getStateFromMeta(int meta)
+	public IBlockState getStateFromMeta( int meta )
 	{
-		return this.getDefaultState().withProperty(BRIGHTNESS, meta);
+		return this.getDefaultState().withProperty( BRIGHTNESS, meta );
 	}
 
 	@Override
-	public int getMetaFromState(IBlockState state)
+	public int getMetaFromState( IBlockState state )
 	{
 		return state.getValue( BRIGHTNESS );
 	}
 
 	@Override
-	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
-		TileEntity tile = world.getTileEntity(pos);
-		if(tile instanceof OpenLightTE) {
-			return state.withProperty( BRIGHTNESS, state.getValue( BRIGHTNESS ) );
-		} else {
-			return state;
-		}
+	public IBlockState getExtendedState( IBlockState state, IBlockAccess world, BlockPos pos )
+	{
+		return state.withProperty( BRIGHTNESS, state.getValue( BRIGHTNESS ) );
 	}
 
 	@Override
 	@Deprecated
-	public int getLightValue(IBlockState state){
-		this.lightValue = state.getValue(BRIGHTNESS);
-		return this.lightValue;
+	public int getLightValue( IBlockState state )
+	{
+		lightValue = state.getValue( BRIGHTNESS );
+		return lightValue;
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World arg0, int arg1) {
-		return new OpenLightTE();
+	public int getLightValue( IBlockState state, IBlockAccess world, BlockPos pos )
+	{
+		return getLightValue( state );
 	}
 
+	@Override
+	public TileEntity createNewTileEntity( World arg0, int arg1 )
+	{
+		return new OpenLightTE();
+	}
 }

--- a/src/main/java/pcl/openlights/tileentity/OpenLightTE.java
+++ b/src/main/java/pcl/openlights/tileentity/OpenLightTE.java
@@ -12,9 +12,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -31,39 +31,46 @@ import pcl.openlights.blocks.LightBlock;
 })
 
 // NOTE: IColoredLight is to be removed after 1.12.2. See comment in IColoredLight for more details.
-@SuppressWarnings("deprecation")
-public class OpenLightTE extends TileEntity implements SimpleComponent, ILightProvider, com.elytradev.mirage.lighting.IColoredLight {
+@SuppressWarnings( "deprecation" )
+public class OpenLightTE extends TileEntity implements ITickable, SimpleComponent, ILightProvider, com.elytradev.mirage.lighting.IColoredLight
+{
 
 	private int color = 0xFFFFFF;
 	private int brightness = 0;
+	private boolean updateOnTick = true;
 
-	public OpenLightTE() {}
+	public OpenLightTE()
+	{
+		// Do nothing.
+	}
 
 	@Override
-	public String getComponentName() {
+	public String getComponentName()
+	{
 		return "openlight";
 	}
 
 	@Override
-	public void readFromNBT(NBTTagCompound nbt)
+	public void readFromNBT( NBTTagCompound nbt )
 	{
-		super.readFromNBT(nbt);
-		color = nbt.getInteger("color");
-		brightness = nbt.getInteger("brightness");
+		super.readFromNBT( nbt );
+		color = nbt.getInteger( "color" );
+		brightness = nbt.getInteger( "brightness" );
 	}
 
 	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt)
+	public NBTTagCompound writeToNBT( NBTTagCompound nbt )
 	{
-		super.writeToNBT(nbt);
-		nbt.setInteger("color", Integer.parseInt(getColor(), 16));
-		nbt.setInteger("brightness", getBrightness());
+		super.writeToNBT( nbt );
+		nbt.setInteger( "color", getColor() );
+		nbt.setInteger( "brightness", getBrightness() );
 		return nbt;
 	}
 
 	@Callback
-	public Object[] greet(Context context, Arguments args) {
-		return new Object[] { "Lasciate ogne speranza, voi ch'entrate" };
+	public Object[] greet( Context context, Arguments args )
+	{
+		return new Object[]{ "Lasciate ogne speranza, voi ch'entrate" };
 	}
 
 	// TODO QMX: If QMX considers making an official fork, use ColorValue class from QMXMCStdLib to support ordinal and RGB color values.
@@ -73,20 +80,15 @@ public class OpenLightTE extends TileEntity implements SimpleComponent, ILightPr
 	{
 		if( args.count() != 1 )
 			throw new Exception( "Invalid number of arguments, expected 1" );
-		
+
 		int buf = args.checkInteger( 0 );
-		
-		if ( ( buf > 0xFFFFFF ) || ( buf < 0x000000 ) )
+
+		if( ( buf > 0xFFFFFF ) || ( buf < 0x000000 ) )
 			throw new Exception( "Valid RGB range is 0x000000 to 0xFFFFFF" );
-		
-		color = buf;
-		
-		getUpdateTag();
-		world.notifyBlockUpdate( pos, world.getBlockState( pos ), world.getBlockState( pos ), 2 );
-		world.markBlockRangeForRenderUpdate( pos, pos );
-		markDirty();
-		
-		return new Object[] { getColor() };
+
+		setColor( buf );
+
+		return new Object[]{ getColorString() };
 	}
 
 	@Callback( doc = "function(brightness:number):number; Set the brightness of the light. Returns the new brightness.", direct = true, limit = 32 )
@@ -94,111 +96,140 @@ public class OpenLightTE extends TileEntity implements SimpleComponent, ILightPr
 	{
 		if( args.count() != 1 )
 			throw new Exception( "Invalid number of arguments, expected 1" );
-	
-		int buf = args.checkInteger( 0 );
-		
-		if ( ( buf > 15 ) || ( buf < 0 ) )
-			throw new Exception( "Valid brightness range is 0 to 15" );
-		
-		brightness = buf;
 
-		( ( WorldServer ) world ).addScheduledTask( new Runnable()
-		{
-			@Override
-			public void run()
-			{
-				IBlockState state = world.getBlockState( pos );
-				world.setBlockState( pos, state.withProperty( LightBlock.BRIGHTNESS, brightness ) );
-			}
-		});
-		
-		getUpdateTag();
-		world.notifyBlockUpdate( pos, world.getBlockState( pos ), world.getBlockState( pos ), 2 );
-		world.markBlockRangeForRenderUpdate( pos, pos );
-		markDirty();
-		
-		return new Object[] { getBrightness() };
+		int buf = args.checkInteger( 0 );
+
+		if( ( buf > 15 ) || ( buf < 0 ) )
+			throw new Exception( "Valid brightness range is 0 to 15" );
+
+		setBrightness( buf );
+
+		return new Object[]{ getBrightness() };
 	}
 
 	@Callback( doc = "function():string; Get the light color as an RGB hex string. Use `tonumber(value, 16)' to convert return value to a usable numeric value.", direct = true, limit = 32 )
-	public Object[] getColor(Context context, Arguments args) {
-		return new Object[] { getColor() };
+	public Object[] getColor( Context context, Arguments args )
+	{
+		return new Object[]{ getColorString() };
 	}
 
 	@Callback( doc = "function():number; Get the brightness of the light.", direct = true, limit = 32 )
-	public Object[] getBrightness(Context context, Arguments args) {
-		return new Object[] { getBrightness() };
+	public Object[] getBrightness( Context context, Arguments args )
+	{
+		return new Object[]{ getBrightness() };
 	}
 
-	public String getColor() {
-		return String.format("%06X", (0xFFFFFF & this.color));
-	}
-
-	public int getBrightness() {
-		return world.getBlockState(pos).getValue( LightBlock.BRIGHTNESS );
-	}
-
-	public int getLampColor() {
+	public int getColor()
+	{
 		return color;
 	}
-	
+
+	public String getColorString()
+	{
+		return String.format( "%06X", ( 0xFFFFFF & getColor() ) );
+	}
+
+	public int getBrightness()
+	{
+		return brightness;
+	}
+
+	public void setBrightness( int brightness )
+	{
+		this.brightness = brightness;
+		updateOnTick();
+	}
+
+	public void setColor( int color )
+	{
+		this.color = color;
+		updateOnTick();
+	}
+
+	protected void updateOnTick()
+	{
+		updateOnTick = true;
+	}
+
+	@Override
+	public void update()
+	{
+		if( updateOnTick )
+		{
+			if( !world.isRemote )
+			{
+				if( world.getBlockState( getPos() ).getBlock() instanceof LightBlock )
+				{
+					if( world.getBlockState( getPos() ).getValue( LightBlock.BRIGHTNESS ) != brightness )
+						world.setBlockState( getPos(), world.getBlockState( getPos() ).withProperty( LightBlock.BRIGHTNESS, brightness ) );
+
+					getUpdateTag();
+					world.notifyBlockUpdate( getPos(), world.getBlockState( getPos() ), world.getBlockState( getPos() ), 2 );
+					world.markBlockRangeForRenderUpdate( getPos(), getPos() );
+					markDirty();
+				}
+			}
+
+			updateOnTick = false;
+		}
+	}
+
 	@Override
 	@SideOnly( Side.CLIENT )
 	@Optional.Method( modid = "albedo" )
-    public elucent.albedo.lighting.Light provideLight()
-    {
-        return elucent.albedo.lighting.Light.builder()
-			.pos( getPos() )
-			.color( color, false )
-			.radius( brightness )
-			.build();
-    }
-    
+	public elucent.albedo.lighting.Light provideLight()
+	{
+		return elucent.albedo.lighting.Light.builder()
+				.pos( getPos() )
+				.color( getColor(), false )
+				.radius( getBrightness() )
+				.build();
+	}
+
 	@Nullable
 	@Override
 	@SideOnly( Side.CLIENT )
 	@Optional.Method( modid = "mirage" )
-	public com.elytradev.mirage.lighting.Light getColoredLight() {
+	public com.elytradev.mirage.lighting.Light getColoredLight()
+	{
 		return com.elytradev.mirage.lighting.Light.builder()
-			.pos( getPos() )
-			.color( color, false )
-			.radius( brightness )
-			.build();
+				.pos( getPos() )
+				.color( getColor(), false )
+				.radius( getBrightness() )
+				.build();
 	}
 
 	@Override
 	@Nullable
-	public SPacketUpdateTileEntity getUpdatePacket() {
-		return new SPacketUpdateTileEntity(getPos(), 0, getUpdateTag());
+	public SPacketUpdateTileEntity getUpdatePacket()
+	{
+		return new SPacketUpdateTileEntity( getPos(), 0, getUpdateTag() );
 	}
 
 	@Override
-	public NBTTagCompound getUpdateTag() {
+	public NBTTagCompound getUpdateTag()
+	{
 		NBTTagCompound tagCom = super.getUpdateTag();
-		this.writeToNBT(tagCom);
+		writeToNBT( tagCom );
 		return tagCom;
 	}
 
 	@Override
-	public void handleUpdateTag(NBTTagCompound tag) {
-		this.readFromNBT(tag);
+	public void handleUpdateTag( NBTTagCompound tag )
+	{
+		this.readFromNBT( tag );
 	}
 
 	@Override
-	public void onDataPacket(NetworkManager net, SPacketUpdateTileEntity packet) {
-			readFromNBT(packet.getNbtCompound());
-			IBlockState state = this.world.getBlockState(this.pos);
-			this.world.notifyBlockUpdate(pos, state, state, 3);
-	}
-	
-	public boolean writeNBTToDescriptionPacket()
+	public void onDataPacket( NetworkManager net, SPacketUpdateTileEntity packet )
 	{
-		return true;
+		readFromNBT( packet.getNbtCompound() );
+		world.notifyBlockUpdate( getPos(), world.getBlockState( getPos() ), world.getBlockState( getPos() ), 3 );
 	}
 
 	@Override
-	public boolean shouldRefresh(World world, BlockPos pos, IBlockState oldState, IBlockState newState)
+	public boolean shouldRefresh( World world, BlockPos pos, IBlockState oldState, IBlockState newState )
 	{
-		return (oldState.getBlock() != newState.getBlock());
+		return ( oldState.getBlock() != newState.getBlock() );
 	}
 }

--- a/src/main/java/pcl/openlights/util/ConcurrentlyLoadedColoredLightsModException.java
+++ b/src/main/java/pcl/openlights/util/ConcurrentlyLoadedColoredLightsModException.java
@@ -9,31 +9,34 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly( Side.CLIENT )
 public class ConcurrentlyLoadedColoredLightsModException extends CustomModLoadingErrorDisplayException
 {
-	public void initGui( GuiErrorScreen errorScreen, FontRenderer fontRenderer ) {}
-	
+	public void initGui( GuiErrorScreen errorScreen, FontRenderer fontRenderer )
+	{
+		// Do nothing.
+	}
+
 	public void drawScreen( GuiErrorScreen errorScreen, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime )
 	{
 		int offset = 75;
-		
+
 		errorScreen.drawDefaultBackground();
 		errorScreen.drawCenteredString( fontRenderer, "Albedo and Mirage are both loaded.", ( errorScreen.width / 2 ), offset, 0xFFFFFF );
-		
+
 		offset += 25;
-		
+
 		errorScreen.drawCenteredString( fontRenderer, "These core mods are mutually exclusive and must not be loaded simultaneously.", ( errorScreen.width / 2 ), offset, 0xEEEEEE );
-		
+
 		offset += 15;
-		
+
 		errorScreen.drawCenteredString( fontRenderer, "This error exists to prevent undefined behaviour which would otherwise occur", ( errorScreen.width / 2 ), offset, 0xEEEEEE );
-		
+
 		offset += 15;
-		
+
 		errorScreen.drawCenteredString( fontRenderer, "(e.g. broken texture and lighting renderer).", ( errorScreen.width / 2 ), offset, 0xEEEEEE );
-		
+
 		offset += 25;
-		
+
 		errorScreen.drawCenteredString( fontRenderer, "Please use only one of these core mods.", ( errorScreen.width / 2 ), offset, 0xFFFFFF );
-		
+
 		offset += 25;
 	}
 }


### PR DESCRIPTION
Eh, commit message is mostly self-explanitory:

* Fixed an issue where the client would fatally error due to the wrong TE finding its way into ClientProxy.BlockColorHandler.colorMultiplier(). (Also fixes a fatal issue currently present in OpenLightTE.getBrightness())

* Fixed an issue where vanilla light was not actually being emitted (may have only occurred in testing).

* Implemented ITickable from OpenLightTE so we can just use an internal flag to trigger updates. (note: update() runs in the server thread anyway, so we can do this instead of scheduling a task)

* A little cleanup (some unnecessary translations, checks, etc...)

Also IntelliJ decided to reformat some code now that I'm using it -- this is based on our code-formatting guidelines, so any code coming from myself or QMX should be within such guidelines.